### PR TITLE
Add basic CRUD generator support

### DIFF
--- a/User.java
+++ b/User.java
@@ -1,0 +1,2 @@
+public class User {
+}

--- a/cmd/crudCmd.go
+++ b/cmd/crudCmd.go
@@ -1,0 +1,28 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/sivaprasadreddy/progen/generators/crud"
+	"github.com/spf13/cobra"
+)
+
+var crudCmd = &cobra.Command{
+	Use:   "crud [entity]",
+	Short: "Generate CRUD code for an entity",
+	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) == 0 {
+			fmt.Println("Please provide an entity name. Example: progen crud User")
+			return
+		}
+
+		entity := args[0]
+		crud.Generate(entity)
+
+		fmt.Println("CRUD file generated successfully")
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(crudCmd)
+}

--- a/generated/User.java
+++ b/generated/User.java
@@ -1,0 +1,2 @@
+public class User {
+}

--- a/generators/crud/generator.go
+++ b/generators/crud/generator.go
@@ -1,0 +1,22 @@
+package crud
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+func Generate(entity string) {
+	dir := "generated"
+
+	_ = os.MkdirAll(dir, 0755)
+
+	filename := filepath.Join(dir, entity+".java")
+
+	content := fmt.Sprintf(
+		"public class %s {\n}\n",
+		entity,
+	)
+
+	_ = os.WriteFile(filename, []byte(content), 0644)
+}


### PR DESCRIPTION
This PR introduces a basic CRUD generator command.

- Adds a new `crud` CLI command
- Implements initial CRUD generator scaffold
- Generates a simple Java class under `generated/` directory

This is a foundation for extending CRUD generation with templates and multiple layers.

Closes #28

